### PR TITLE
Add ledger volume to the archive relay image

### DIFF
--- a/archive-relay-docker-image.nix
+++ b/archive-relay-docker-image.nix
@@ -5,7 +5,8 @@ dockerTools.buildLayeredImage {
   tag = "latest";
   contents = [ zeko_archive_relay bash pkgs.cacert ];
   config = {
-    Entrypoint = [ "/bin/zeko-archive-relay" ];
+    Entrypoint = [ "/bin/zeko-archive-relay", "--ledger-cache", "/ledger-cache" ];
     Env = [ "NIX_SSL_CERT_FILE=/etc/ssl/certs/ca-bundle.crt" ];
+    Volumes = { "/ledger-cache" = {}; };
   };
 }


### PR DESCRIPTION
Ledger volume is needed if the archive relay container would be destroyed.